### PR TITLE
Fixed fall-through warning/error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.ko
 *.o
+*.mod
 *.mod.c
 .tmp_versions/
 *.order

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean:
 	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) clean
 
 dkms-install:
+	dkms --version >> /dev/null
 	mkdir -p $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/dkms.conf $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/Makefile $(DKMS_ROOT_PATH)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) clean
 
 dkms-install:
-	mkdir $(DKMS_ROOT_PATH)
+	mkdir -p $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/dkms.conf $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/Makefile $(DKMS_ROOT_PATH)
 	cp $(CURDIR)/zenpower.c $(DKMS_ROOT_PATH)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION         := 0.1.12
+VERSION         := 0.2.0
 TARGET          := $(shell uname -r)
 DKMS_ROOT_PATH  := /usr/src/zenpower-$(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Zenpower
-Zenpower is Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs.
+Zenpower3 is a Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs, now with Zen 3 support!
 
 Make sure that your Linux kernel have support for your CPUs as Zenpower is using kernel function `amd_smn_read` to read values from SMN. A fallback method (which may or may not work!) will be used when it is detected that kernel function `amd_smn_read` lacks support for your CPU.
 For AMD family 17h Model 70h (Ryzen 3000) CPUs you need kernel version 5.3.4 or newer or kernel with this patch: https://patchwork.kernel.org/patch/11043277/
@@ -11,8 +11,8 @@ You can install this module via dkms.
 ```
 sudo apt install dkms git build-essential linux-headers-$(uname -r)
 cd ~
-git clone https://github.com/ocerman/zenpower.git
-cd zenpower
+git clone https://github.com/Ta180m/zenpower3.git
+cd zenpower3
 sudo make dkms-install
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ sudo make dkms-install
 ### Installation for Arch
 You can install the [AUR package](https://aur.archlinux.org/packages/zenpower3-dkms/).
 
+### Installation for Fedora 35+
+You can install it from the [copr package repo](https://copr.fedorainfracloud.org/coprs/birkch/zenpower3/)
+
 ## Module activation
 Because zenpower is using same PCI device as k10temp, you have to disable k10temp first. This is automatically done by the AUR package.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Zenpower
+# Zenpower3
 Zenpower3 is a Linux kernel driver for reading temperature, voltage(SVI2), current(SVI2) and power(SVI2) for AMD Zen family CPUs, now with Zen 3 support!
 
 Make sure that your Linux kernel have support for your CPUs as Zenpower is using kernel function `amd_smn_read` to read values from SMN. A fallback method (which may or may not work!) will be used when it is detected that kernel function `amd_smn_read` lacks support for your CPU.

--- a/README.md
+++ b/README.md
@@ -5,16 +5,19 @@ Make sure that your Linux kernel have support for your CPUs as Zenpower is using
 For AMD family 17h Model 70h (Ryzen 3000) CPUs you need kernel version 5.3.4 or newer or kernel with this patch: https://patchwork.kernel.org/patch/11043277/
 
 ## Installation
-You can install this module via dkms.
+You can install this module via DKMS.
 
-### Installation commands for Ubuntu
-```
+### Installation for Ubuntu
+```sh
 sudo apt install dkms git build-essential linux-headers-$(uname -r)
 cd ~
 git clone https://github.com/Ta180m/zenpower3.git
 cd zenpower3
 sudo make dkms-install
 ```
+
+### Installation for Arch
+You can install the [AUR package](https://aur.archlinux.org/packages/zenpower3-dkms/).
 
 ## Module activation
 Because zenpower is using same PCI device as k10temp, you have to disable k10temp first.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo make dkms-install
 You can install the [AUR package](https://aur.archlinux.org/packages/zenpower3-dkms/).
 
 ## Module activation
-Because zenpower is using same PCI device as k10temp, you have to disable k10temp first.
+Because zenpower is using same PCI device as k10temp, you have to disable k10temp first. This is automatically done by the AUR package.
 
 1. Check if k10temp is active. `lsmod | grep k10temp`
 2. Unload k10temp `sudo modprobe -r k10temp`
@@ -30,7 +30,7 @@ Because zenpower is using same PCI device as k10temp, you have to disable k10tem
 *If k10temp is not blacklisted, you may have to manually unload k10temp after each restart.
 
 ## Sensors monitoring
-You can use this app: [zenmonitor](https://github.com/ocerman/zenmonitor), or your favourie sensors monitoring software
+You can use the `sensors` command, [zenmonitor3](https://github.com/Ta180m/zenmonitor3), or your favorite sensors monitoring software.
 
 ## Update instructions
 1. Unload zenpower `sudo modprobe -r zenpower`

--- a/zenpower.c
+++ b/zenpower.c
@@ -38,7 +38,11 @@
 MODULE_DESCRIPTION("AMD ZEN family CPU Sensors Driver");
 MODULE_AUTHOR("Ondrej Čerman");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("0.1.12");
+MODULE_VERSION("0.1.12-ZEN3-test4");
+
+static bool zen1_calc;
+module_param(zen1_calc, bool, 0);
+MODULE_PARM_DESC(zen1_calc, "Set to 1 to use ZEN1 calculation");
 
 
 #ifndef PCI_DEVICE_ID_AMD_17H_DF_F3
@@ -61,6 +65,13 @@ MODULE_VERSION("0.1.12");
 #define PCI_DEVICE_ID_AMD_17H_M70H_DF_F3    0x1443
 #endif
 
+/* ZEN3 */
+#ifndef PCI_DEVICE_ID_AMD_19H_DF_F3
+#define PCI_DEVICE_ID_AMD_19H_DF_F3         0x1653
+#endif
+
+/* F17H_M01H_SVI, should be renamed to something generic I think... */
+
 #define F17H_M01H_REPORTED_TEMP_CTRL        0x00059800
 #define F17H_M01H_SVI                       0x0005A000
 #define F17H_M01H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0xC)
@@ -69,6 +80,13 @@ MODULE_VERSION("0.1.12");
 #define F17H_M30H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0x10)
 #define F17H_M70H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0x10)
 #define F17H_M70H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0xC)
+/* ZEN3 SP3/TR */
+#define F19H_M01H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0x14)
+#define F19H_M01H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0x10)
+/* ZEN3 Ryzen desktop */
+#define F19H_M21H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0x10)
+#define F19H_M21H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0xC)
+
 #define F17H_M70H_CCD_TEMP(x)               (0x00059954 + ((x) * 4))
 
 #define F17H_TEMP_ADJUST_MASK               0x80000
@@ -595,7 +613,13 @@ static int zenpower_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 				break;
 
 			case 0x31: // Zen2 Threadripper/EPYC
-				data->zen2 = true;
+				/* fixme: add helper for that */
+				if (!zen1_calc) {
+					data->zen2 = true;
+					dev_info(dev, "Using ZEN2 calculation formula.\n");
+				} else {
+					dev_info(dev, "Using ZEN1 calculation formula.\n");
+				}
 				data->amps_visible = true;
 				data->svi_core_addr = F17H_M30H_SVI_TEL_PLANE0;
 				data->svi_soc_addr = F17H_M30H_SVI_TEL_PLANE1;
@@ -603,22 +627,60 @@ static int zenpower_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 				break;
 
 			case 0x60: // Zen2 APU
-				data->zen2 = true;
+				if (!zen1_calc) {
+					data->zen2 = true;
+					dev_info(dev, "Using ZEN2 calculation formula.\n");
+				} else {
+					dev_info(dev, "Using ZEN1 calculation formula.\n");
+				}
 				break;
 
 			case 0x71: // Zen2 Ryzen
-				data->zen2 = true;
+				if (!zen1_calc) {
+					data->zen2 = true;
+					dev_info(dev, "Using ZEN2 calculation formula.\n");
+				} else {
+					dev_info(dev, "Using ZEN1 calculation formula.\n");
+				}
 				data->amps_visible = true;
 				data->svi_core_addr = F17H_M70H_SVI_TEL_PLANE0;
 				data->svi_soc_addr = F17H_M70H_SVI_TEL_PLANE1;
 				ccd_check = 8;
 				break;
-
-			default:
+		}
+	} else if (boot_cpu_data.x86 == 0x19) {
+			switch (boot_cpu_data.x86_model) {
+			case 0x0 ... 0x1: /* Zen3 SP3/TR */
+				if (!zen1_calc) {
+					/* The code need refactoring but calculation is the same
+					 * Is this per Server/Desktop/APU?. EG: each one has his own set of formula(s)?
+					*/
+					data->zen2 = true;
+					dev_info(dev, "Using ZEN2 calculation formula.\n");
+				} else {
+					dev_info(dev, "Using ZEN1 calculation formula.\n");
+				}
+				data->amps_visible = true;
+				data->svi_core_addr = F19H_M01H_SVI_TEL_PLANE0;
+				data->svi_soc_addr = F19H_M01H_SVI_TEL_PLANE1;
+				ccd_check = 8; /* max 64C, 8C per CCD = max 8 CCDs */
+				break;
+			case 0x21:       /* Zen3 Ryzen */
+				if (!zen1_calc) {
+					data->zen2 = true;
+					dev_info(dev, "using ZEN2 calculation formula.\n");
+				} else {
+					dev_info(dev, "using ZEN1 calculation formula.\n");
+				}
+				data->amps_visible = true;
+				data->svi_core_addr = F19H_M21H_SVI_TEL_PLANE0;
+				data->svi_soc_addr = F19H_M21H_SVI_TEL_PLANE1;
+				ccd_check = 2; /* max 16C, 8C per CCD = max 2 CCD's */
+				break;
+			}
+	} else {
 				data->svi_core_addr = F17H_M01H_SVI_TEL_PLANE0;
 				data->svi_soc_addr = F17H_M01H_SVI_TEL_PLANE1;
-				break;
-		}
 	}
 
 	for (i = 0; i < ccd_check; i++) {
@@ -652,6 +714,7 @@ static const struct pci_device_id zenpower_id_table[] = {
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M30H_DF_F3) },
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M60H_DF_F3) },
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M70H_DF_F3) },
+	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_19H_DF_F3) },
 	{}
 };
 MODULE_DEVICE_TABLE(pci, zenpower_id_table);

--- a/zenpower.c
+++ b/zenpower.c
@@ -70,12 +70,12 @@ MODULE_PARM_DESC(zen1_calc, "Set to 1 to use ZEN1 calculation");
 #define PCI_DEVICE_ID_AMD_19H_DF_F3         0x1653
 #endif
 
-#ifndef PCI_DEVICE_ID_AMD_19H_M40H_DF_F4
-#define PCI_DEVICE_ID_AMD_19H_M40H_DF_F4 0x167d
+#ifndef PCI_DEVICE_ID_AMD_19H_M40H_DF_F3
+#define PCI_DEVICE_ID_AMD_19H_M40H_DF_F3 0x167d
 #endif
 
-#ifndef PCI_DEVICE_ID_AMD_19H_M50H_DF_F4
-#define PCI_DEVICE_ID_AMD_19H_M50H_DF_F4 0x166e
+#ifndef PCI_DEVICE_ID_AMD_19H_M50H_DF_F3
+#define PCI_DEVICE_ID_AMD_19H_M50H_DF_F3 0x166e
 #endif
 
 /* F17H_M01H_SVI, should be renamed to something generic I think... */

--- a/zenpower.c
+++ b/zenpower.c
@@ -94,6 +94,9 @@ MODULE_PARM_DESC(zen1_calc, "Set to 1 to use ZEN1 calculation");
 /* ZEN3 Ryzen desktop */
 #define F19H_M21H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0x10)
 #define F19H_M21H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0xC)
+/* ZEN3 APU */
+#define F19H_M50H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0xC)
+#define F19H_M50H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0x10)
 
 #define F17H_M70H_CCD_TEMP(x)               (0x00059954 + ((x) * 4))
 
@@ -692,6 +695,10 @@ static int zenpower_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 				} else {
 					dev_info(dev, "using ZEN1 calculation formula.\n");
 				}
+				data->amps_visible = true;
+				data->svi_core_addr = F19H_M50H_SVI_TEL_PLANE0;
+				data->svi_soc_addr = F19H_M50H_SVI_TEL_PLANE1;
+				ccd_check = 2;
 				break;
 			}
 	} else {

--- a/zenpower.c
+++ b/zenpower.c
@@ -71,11 +71,11 @@ MODULE_PARM_DESC(zen1_calc, "Set to 1 to use ZEN1 calculation");
 #endif
 
 #ifndef PCI_DEVICE_ID_AMD_19H_M40H_DF_F3
-#define PCI_DEVICE_ID_AMD_19H_M40H_DF_F3 0x167d
+#define PCI_DEVICE_ID_AMD_19H_M40H_DF_F3	0x167c
 #endif
 
 #ifndef PCI_DEVICE_ID_AMD_19H_M50H_DF_F3
-#define PCI_DEVICE_ID_AMD_19H_M50H_DF_F3 0x166e
+#define PCI_DEVICE_ID_AMD_19H_M50H_DF_F3	0x166d
 #endif
 
 /* F17H_M01H_SVI, should be renamed to something generic I think... */

--- a/zenpower.c
+++ b/zenpower.c
@@ -82,10 +82,13 @@ MODULE_PARM_DESC(zen1_calc, "Set to 1 to use ZEN1 calculation");
 
 #define F17H_M01H_REPORTED_TEMP_CTRL        0x00059800
 #define F17H_M01H_SVI                       0x0005A000
+#define F17H_M02H_SVI                       0x0006F000
 #define F17H_M01H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0xC)
 #define F17H_M01H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0x10)
 #define F17H_M30H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0x14)
 #define F17H_M30H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0x10)
+#define F17H_M60H_SVI_TEL_PLANE0            (F17H_M02H_SVI + 0x38)
+#define F17H_M60H_SVI_TEL_PLANE1            (F17H_M02H_SVI + 0x3C)
 #define F17H_M70H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0x10)
 #define F17H_M70H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0xC)
 /* ZEN3 SP3/TR */
@@ -95,8 +98,8 @@ MODULE_PARM_DESC(zen1_calc, "Set to 1 to use ZEN1 calculation");
 #define F19H_M21H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0x10)
 #define F19H_M21H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0xC)
 /* ZEN3 APU */
-#define F19H_M50H_SVI_TEL_PLANE0            (F17H_M01H_SVI + 0xC)
-#define F19H_M50H_SVI_TEL_PLANE1            (F17H_M01H_SVI + 0x10)
+#define F19H_M50H_SVI_TEL_PLANE0            (F17H_M02H_SVI + 0x38)
+#define F19H_M50H_SVI_TEL_PLANE1            (F17H_M02H_SVI + 0x3C)
 
 #define F17H_M70H_CCD_TEMP(x)               (0x00059954 + ((x) * 4))
 
@@ -242,7 +245,7 @@ int static debug_addrs_arr[] = {
 	F17H_M01H_SVI + 0x14, 0x000598BC, 0x0005994C, F17H_M70H_CCD_TEMP(0),
 	F17H_M70H_CCD_TEMP(1), F17H_M70H_CCD_TEMP(2), F17H_M70H_CCD_TEMP(3),
 	F17H_M70H_CCD_TEMP(4), F17H_M70H_CCD_TEMP(5), F17H_M70H_CCD_TEMP(6),
-	F17H_M70H_CCD_TEMP(7)
+	F17H_M70H_CCD_TEMP(7), F17H_M02H_SVI + 0x38, F17H_M02H_SVI + 0x3C
 };
 
 static ssize_t debug_data_show(struct device *dev,
@@ -644,6 +647,10 @@ static int zenpower_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 				} else {
 					dev_info(dev, "Using ZEN1 calculation formula.\n");
 				}
+				data->amps_visible = true;
+				data->svi_core_addr = F17H_M60H_SVI_TEL_PLANE0;
+				data->svi_soc_addr = F17H_M60H_SVI_TEL_PLANE1;
+				ccd_check = 8;
 				break;
 
 			case 0x71: // Zen2 Ryzen

--- a/zenpower.c
+++ b/zenpower.c
@@ -1,7 +1,7 @@
 /*
  * Zenpower - Driver for reading temperature, voltage, current and power for AMD 17h CPUs
  *
- * Copyright (c) 2018-2020 Ondrej Čerman
+ * Copyright (c) 2018-2021 Anthony Wang
  *
  * This driver is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License; either
@@ -18,6 +18,8 @@
  */
 
 /*
+ * forked from the original zenpower by Ondrej Čerman
+ *
  * based on k10temp by Clemens Ladisch
  *
  * Docs:
@@ -36,9 +38,9 @@
 #include <asm/amd_nb.h>
 
 MODULE_DESCRIPTION("AMD ZEN family CPU Sensors Driver");
-MODULE_AUTHOR("Ondrej Čerman");
+MODULE_AUTHOR("Anthony Wang");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("0.1.12-ZEN3-test4");
+MODULE_VERSION("0.2.0");
 
 static bool zen1_calc;
 module_param(zen1_calc, bool, 0);

--- a/zenpower.c
+++ b/zenpower.c
@@ -70,6 +70,14 @@ MODULE_PARM_DESC(zen1_calc, "Set to 1 to use ZEN1 calculation");
 #define PCI_DEVICE_ID_AMD_19H_DF_F3         0x1653
 #endif
 
+#ifndef PCI_DEVICE_ID_AMD_19H_M40H_DF_F4
+#define PCI_DEVICE_ID_AMD_19H_M40H_DF_F4 0x167d
+#endif
+
+#ifndef PCI_DEVICE_ID_AMD_19H_M50H_DF_F4
+#define PCI_DEVICE_ID_AMD_19H_M50H_DF_F4 0x166e
+#endif
+
 /* F17H_M01H_SVI, should be renamed to something generic I think... */
 
 #define F17H_M01H_REPORTED_TEMP_CTRL        0x00059800
@@ -723,6 +731,8 @@ static const struct pci_device_id zenpower_id_table[] = {
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M60H_DF_F3) },
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_17H_M70H_DF_F3) },
 	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_19H_DF_F3) },
+	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_19H_M40H_DF_F3) },
+	{ PCI_VDEVICE(AMD, PCI_DEVICE_ID_AMD_19H_M50H_DF_F3) },
 	{}
 };
 MODULE_DEVICE_TABLE(pci, zenpower_id_table);

--- a/zenpower.c
+++ b/zenpower.c
@@ -677,6 +677,14 @@ static int zenpower_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 				data->svi_soc_addr = F19H_M21H_SVI_TEL_PLANE1;
 				ccd_check = 2; /* max 16C, 8C per CCD = max 2 CCD's */
 				break;
+			case 0x50:	/* Zen3 APU */
+				if (!zen1_calc) {
+					data->zen2 = true;
+					dev_info(dev, "using ZEN2 calculation formula.\n");
+				} else {
+					dev_info(dev, "using ZEN1 calculation formula.\n");
+				}
+				break;
 			}
 	} else {
 				data->svi_core_addr = F17H_M01H_SVI_TEL_PLANE0;

--- a/zenpower.mod
+++ b/zenpower.mod
@@ -1,2 +1,0 @@
-/home/ta180m/git/zenpower3/zenpower.o
-

--- a/zenpower.mod
+++ b/zenpower.mod
@@ -1,0 +1,2 @@
+/home/ta180m/git/zenpower3/zenpower.o
+

--- a/zp_read_debug.sh
+++ b/zp_read_debug.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+hwmon="/sys/class/hwmon"
+mdevs=`ls $hwmon`
+zenmon=""
+ok=0
+
+for dev in $mdevs; do
+    path="$hwmon/$dev"
+    devname=`cat $path/name`
+    if [ "$devname" == "zenpower" ]; then
+        cat $path/debug_data
+        ok=1
+    fi
+done
+
+if [ $ok -ne 1 ]; then
+    echo "Zenpower not found"
+    exit
+fi


### PR DESCRIPTION
On some platforms fall-through warning is treated as an error: -Werror=implicit-fallthrough is set to 5 so the comment is disregarded. Setting the flag to 3 ensures a successful build. 